### PR TITLE
chore: updated index to include joi npm anchor

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,6 +10,9 @@
       <a class="index-button" href="/api" aria-label="get-started-button"
         >Get started with joi</a
       >
+      <a href="https://www.npmjs.com/package/joi" target="_blank"
+        >npm install joi</a
+      >
     </section>
   </main>
 </template>


### PR DESCRIPTION
**Changelog**
- Include Joi Npm install anchor on the landing page for `joi.dev`

**Local Preview**
<img width="944" alt="image" src="https://github.com/hapijs/joi.dev/assets/56465610/ec01596a-58c1-4f41-9a08-644705977517">
